### PR TITLE
review: Eslintの設定の改善をする試み

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
 		],
 		"no-useless-escape":"error",
 		"camelcase": "off",
+		"no-invalid-this": "error",
 		"prettier/prettier": [
 			"error",
 			{

--- a/js/common.js
+++ b/js/common.js
@@ -133,10 +133,10 @@ export function showCards(permalink_obj) {
 					});
 					toot_div.setAttribute("draggable", "true");
 					toot_div.setAttribute("data-dblclickable", "true");
-					toot_div.addEventListener("dragstart", handleDragStart, false);
-					toot_div.addEventListener("dragover", handleDragOver, false);
-					toot_div.addEventListener("drop", handleDrop, false);
-					toot_div.addEventListener("dragend", handleDragEnd, false);
+					toot_div.addEventListener("dragstart", e => handleDragStart(e), false);
+					toot_div.addEventListener("dragover", e => handleDragOver(e), false);
+					toot_div.addEventListener("drop", e => handleDrop(e), false);
+					toot_div.addEventListener("dragend", e => handleDragEnd(e), false);
 					max_index++;
 					target_div.appendChild(toot_div);
 				} else {
@@ -157,7 +157,7 @@ export function showCards(permalink_obj) {
 /**
  * @param {Event} e
  */
-function handleDragStart(e) {
+export function handleDragStart(e) {
 	e.dataTransfer.effectAllowed = "move";
 	e.dataTransfer.setData("text/plain", this.id);
 }
@@ -165,7 +165,7 @@ function handleDragStart(e) {
 /**
  * @param {Event} e
  */
-function handleDragOver(e) {
+export function handleDragOver(e) {
 	if (e.preventDefault) {
 		e.preventDefault();
 	}
@@ -174,7 +174,7 @@ function handleDragOver(e) {
 /**
  * @param {Event} e drop event
  */
-function handleDrop(e) {
+export function handleDrop(e) {
 	if (e.preventDefault) {
 		e.preventDefault();
 	}
@@ -220,6 +220,6 @@ function handleDrop(e) {
 	genPermalink();
 }
 
-function handleDragEnd() {
+export function handleDragEnd() {
 	// console.log("drag end");
 }

--- a/js/common.js
+++ b/js/common.js
@@ -127,9 +127,10 @@ export function showCards(permalink_obj) {
 	</div>
 	${media}
 </div>`;
-					toot_div.setAttribute("id", `o_${max_index}`);
+					const idx = max_index;
+					toot_div.setAttribute("id", `o_${idx}`);
 					toot_div.addEventListener("dblclick", () => {
-						deleteCard(max_index, "o");
+						deleteCard(idx, "o");
 					});
 					toot_div.setAttribute("draggable", "true");
 					toot_div.setAttribute("data-dblclickable", "true");

--- a/js/common.js
+++ b/js/common.js
@@ -159,7 +159,7 @@ export function showCards(permalink_obj) {
  */
 export function handleDragStart(e) {
 	e.dataTransfer.effectAllowed = "move";
-	e.dataTransfer.setData("text/plain", this.id);
+	e.dataTransfer.setData("text/plain", e.target.id);
 }
 
 /**


### PR DESCRIPTION
#62 のレビューです。問題がなければ merge してください。
(Windows10 + Chrome で動作確認しています)

まだ動かないままだったので、問題の箇所を探して修正しました。
- ドラッグイベントのハンドラが export されていなかった
- arrow function にしたため、 this の参照がおかしくなって dataTransfer から目的の id が取れていなかった
https://github.com/yumetodo/mastogetter/blob/09a0f028839f2ddc2ee4ebe79575d209e45ae254/js/common.js#L187-L190
- まとめて追加時の削除関数がグローバル変数を参照しているせいで id が正しく取れていなかった
